### PR TITLE
Updated Miami Vice controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Medal of Honor Heroes
 Medal of Honor Heroes 2
 Metal Gear Solid - Peace Walker
 Metal Gear Solid - Portable Ops
-Miami Vice
+Miami Vice (strafe with stick)
 Midnight Club LA Remix
 Monster Hunter Freedom
 Monster Hunter Freedom 2

--- a/camera_patch_lite.ini
+++ b/camera_patch_lite.ini
@@ -780,21 +780,32 @@ camera_right = LEFT
 # Miami Vice
 [ULES-00375]
 enable = TRUE
+trigger_button_1 = TRIANGLE
+camera_up = ANALOG_UP
+camera_down = ANALOG_DOWN
 camera_left = ANALOG_LEFT
 camera_right = ANALOG_RIGHT
 [ULES-00376]
 enable = TRUE
+trigger_button_1 = TRIANGLE
+camera_up = ANALOG_UP
+camera_down = ANALOG_DOWN
 camera_left = ANALOG_LEFT
 camera_right = ANALOG_RIGHT
 [ULUS-10109]
 enable = TRUE
+trigger_button_1 = TRIANGLE
+camera_up = ANALOG_UP
+camera_down = ANALOG_DOWN
 camera_left = ANALOG_LEFT
 camera_right = ANALOG_RIGHT
 [ULJM-05165]
 enable = TRUE
+trigger_button_1 = TRIANGLE
+camera_up = ANALOG_UP
+camera_down = ANALOG_DOWN
 camera_left = ANALOG_LEFT
 camera_right = ANALOG_RIGHT
-
 
 # Jak & Daxter: The Lost Frontier
 [UCES-01225]


### PR DESCRIPTION
The game doesn't have any form of camera control and default configuration is rather not making a good of use of the right stick.

This updates the right stick to behave as a strafe stick, so that there's no need to hold triangle to strafe, aiming will also work with r stick in aim mode (freezes player).